### PR TITLE
Add support for an explicit secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ const raf = require('random-access-file')
 const { key, secretKey } = derivedStorage(name => raf(name), (name, cb) => {
   // derive your keypair here ...
   // if name is null, this keypair is fresh, otherwise derive from that name
+  // you can optionally return a secret key without a name, and that will be stored instead.
   cb(null, {
     name,
     publicKey,
@@ -45,7 +46,10 @@ function (name, cb) {
 ```
 
 Where `name` is a buffer or null containing the name of the keypair. If the name is null you need to return the name of the keypair
-back to the callback and still will be written along with a length prefix to the storage you pass in.
+back to the callback as it still will be written along with a length prefix to the storage you pass in.
+
+If you do not with to derive your secret key from a name, you can override the derivation by returning a secret key and a `null`
+name from this function.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -58,20 +58,15 @@ function keyPair (storage, derive) {
         if (err) return cb(err)
         keyStorage.write(0, res.publicKey, err => {
           if (err) return cb(err)
-          if (res.name) {
-            writeName(res.name, err => {
-              if (err) return cb(err)
-              return cb(null, res)
-            })
-          } else if (res.secretKey) {
-            secretKeyStorage.write(0, res.secretKey, err => {
-              if (err) return cb(err)
-              return cb(null, res)
-            })
-          } else {
-            return cb(new Error('The derivation function did not provide a name or a secret key.'))
-          }
+          if (res.name) return writeName(res.name, done)
+          else if (res.secretKey) return secretKeyStorage.write(0, res.secretKey, done)
+          else return done(new Error('The derivation function did not provide a name or a secret key.'))
         })
+
+        function done (err) {
+          if (err) return cb(err)
+          return cb(null, res)
+        }
       })
     }
   })


### PR DESCRIPTION
If a derivation function returns a secret key but not a name, we should store that secret key. On read, if we can't load a name, we should attempt to load the secret key instead.